### PR TITLE
rviz: display: image: Add NV12 to RGB conversion support in rviz2

### DIFF
--- a/rviz_default_plugins/include/rviz_default_plugins/displays/image/ros_image_texture.hpp
+++ b/rviz_default_plugins/include/rviz_default_plugins/displays/image/ros_image_texture.hpp
@@ -130,6 +130,7 @@ private:
   ImageData convertTo8bit(const uint8_t * data_ptr, size_t data_size_in_bytes);
   ImageData convertUYVYToRGBData(const uint8_t * data_ptr, size_t data_size_in_bytes);
   ImageData convertYUYVToRGBData(const uint8_t * data_ptr, size_t data_size_in_bytes);
+  ImageData convertNV12ToRGBData(const uint8_t * data_ptr, size_t data_size_in_bytes);
 
   ImageData setFormatAndNormalizeDataIfNecessary(
     const std::string & encoding, const uint8_t * data_ptr, size_t data_size_in_bytes);

--- a/rviz_default_plugins/src/rviz_default_plugins/displays/image/ros_image_texture.cpp
+++ b/rviz_default_plugins/src/rviz_default_plugins/displays/image/ros_image_texture.cpp
@@ -233,6 +233,34 @@ struct uyvy
   uint8_t y1;
 };
 
+// Function converts src_img from NV12 format to rgb
+static void imageConvertNV12ToRGB(
+  uint8_t * dst_img,
+  const uint8_t * src_img,
+  int dst_start_row,
+  int dst_end_row,
+  int dst_num_cols,
+  uint32_t stride_in_bytes)
+{
+  const uint8_t * y_ptr = src_img;
+  const uint8_t * uv_ptr = src_img + (dst_end_row * stride_in_bytes);
+
+  for (int row = dst_start_row; row < dst_end_row; row++) {
+    for (int col = 0; col < dst_num_cols; col++) {
+      int y_index = row * stride_in_bytes + col;
+      int uv_index = (row / 2) * stride_in_bytes + (col / 2) * 2;
+
+      int final_y = y_ptr[y_index];
+      int final_u = uv_ptr[uv_index + 0];
+      int final_v = uv_ptr[uv_index + 1];
+
+      std::tie(dst_img[0], dst_img[1], dst_img[2]) = pixelYUVToRGB(final_y, final_u, final_v);
+
+      dst_img += 3;
+    }
+  }
+}
+
 // Function converts src_img from UYVY format to rgb
 static void imageConvertUYVYToRGB(
   uint8_t * dst_img, uint8_t * src_img,
@@ -410,6 +438,20 @@ ROSImageTexture::convertYUYVToRGBData(const uint8_t * data_ptr, size_t data_size
 }
 
 ImageData
+ROSImageTexture::convertNV12ToRGBData(const uint8_t * data_ptr, size_t data_size_in_bytes)
+{
+  size_t new_size_in_bytes = data_size_in_bytes * 2;
+
+  uint8_t * new_data = new uint8_t[new_size_in_bytes];
+
+  imageConvertNV12ToRGB(
+    new_data, const_cast<uint8_t *>(data_ptr),
+    0, height_, width_, width_);
+
+  return ImageData(Ogre::PF_BYTE_RGB, new_data, new_size_in_bytes, true);
+}
+
+ImageData
 ROSImageTexture::setFormatAndNormalizeDataIfNecessary(
   const std::string & encoding, const uint8_t * data_ptr, size_t data_size_in_bytes)
 {
@@ -449,6 +491,8 @@ ROSImageTexture::setFormatAndNormalizeDataIfNecessary(
     return convertUYVYToRGBData(data_ptr, data_size_in_bytes);
   } else if (encoding == sensor_msgs::image_encodings::YUYV) {
     return convertYUYVToRGBData(data_ptr, data_size_in_bytes);
+  } else if (encoding == sensor_msgs::image_encodings::NV12) {
+    return convertNV12ToRGBData(data_ptr, data_size_in_bytes);
   } else {
     throw UnsupportedImageEncoding(encoding);
   }


### PR DESCRIPTION
### Overview
This PR adds NV12-to-RGB conversion functionality to rviz2. It leverages the newly introduced NV12 encoding in the ROS2 common_interfaces (see https://github.com/ros2/common_interfaces/pull/253). 

### Details
- Introduced a dedicated function `convertNV12ToRGBData()` for NV12 images.
- Ensured correct UV plane indexing according to the updated NV12 memory layout.
- Expanded `setFormatAndNormalizeDataIfNecessary()` to handle the "nv12" encoding.
- Verified that the output size is consistent with the expected 3×width×height RGB buffer.

### Rationale
Previously, rviz2 did not include a built-in NV12 conversion, resulting in garbled or miscolored images when receiving NV12-encoded topics. With the new encoding support merged into common_interfaces, this PR provides a seamless way to correctly display NV12 image streams in rviz2.

### Testing
- Tested locally with NV12 image streams from a camera driver.
- Verified that the displayed image colors match the expected RGB output.

### Dependencies
This PR relies on the changes merged in https://github.com/ros2/common_interfaces/pull/253, which introduced the NV12 encoding definition into sensor_msgs.

---

Thank you for reviewing and considering this PR! If you have any questions or need additional information, please let me know.
